### PR TITLE
Allow to capture viewport only

### DIFF
--- a/lib/browser/client-scripts/index.js
+++ b/lib/browser/client-scripts/index.js
@@ -33,9 +33,12 @@ exports.prepareScreenshot = function prepareScreenshot(selectors, opts) {
 };
 
 function prepareScreenshotUnsafe(selectors, opts) {
-    var rect = getCaptureRect(selectors);
-    if (rect.error) {
-        return rect;
+    var rect;
+    if (selectors !== null) {
+        rect = getCaptureRect(selectors);
+        if (rect.error) {
+            return rect;
+        }
     }
 
     var viewportHeight = document.documentElement.clientHeight,
@@ -50,6 +53,9 @@ function prepareScreenshotUnsafe(selectors, opts) {
             height: viewportHeight
         }),
         pixelRatio = opts.usePixelRatio === false ? 1 : window.devicePixelRatio;
+    if (selectors === null) {
+        rect = viewPort;
+    }
 
     if (!viewPort.rectInside(rect)) {
         window.scrollTo(rect.left, rect.top);


### PR DESCRIPTION
Если в клиентский скрипт не были переданы селекторы, это означает, что нужно сделать скриншот всего вьюпорта.

Применения см. в [gemini](https://github.com/gemini-testing/gemini/pull/877)
