### PR TITLE
fix: add package 'sizzle'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2892,6 +2892,11 @@
         }
       }
     },
+    "sizzle": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha1-TrB4w3IxpWtS5Bk/cB5++JN+YGs="
+    },
     "slice-ansi": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "looks-same": "^4.0.0",
     "micromatch": "^2.3.11",
     "png-img": "^2.1.1",
+    "sizzle": "^2.3.3",
     "temp": "^0.8.3",
     "uglify-js": "^2.8.29",
     "uglifyify": "^3.0.4"


### PR DESCRIPTION
Для корректного снятия скриншотов в старых браузеров используется полифил, который использует модуль `sizzle`. При портировании функциональности в `gemini-core`  забыли его добавить. Не заметили раньше, так как при совместном использовании `gemini` и `hermione` пакет приезжает из зависимостей `gemini`, если использовать только `hermione`, то будем падать из-за отсутствующего пакета 😄 