### PR TITLE
Fix incorrect image cropping on iOS

### DIFF
--- a/lib/browser/client-scripts/calibrate.js
+++ b/lib/browser/client-scripts/calibrate.js
@@ -48,7 +48,7 @@
     }
 
     function getBrowserFeatures() {
-        var iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+        var iOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
 
         var features = {
             needsCompatLib: needsCompatLib(),

--- a/lib/browser/client-scripts/calibrate.js
+++ b/lib/browser/client-scripts/calibrate.js
@@ -48,10 +48,13 @@
     }
 
     function getBrowserFeatures() {
+        var iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+
         var features = {
             needsCompatLib: needsCompatLib(),
             pixelRatio: window.devicePixelRatio,
-            innerWidth: window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth
+            // use screen.width for iOS, because innerWidth is always 980
+            innerWidth: (iOS && window.screen.width) || window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth
         };
 
         return features;


### PR DESCRIPTION
Hi Yandex team,

I tried to use Gemini for testing on iOS devices via BrowserStack. Obviously the screenshots were cropped incorrectly. Only the upper left quarter of an component appeared. I suspected a wrong pixel ratio used in the calculation of the cropping area. Indeed a pixel ratio of `1` was used.

Actually an iOS device reports the correct pixel ratio, but the reported screen width is wrong. The wrong width leads to not using the pixel ratio reported by the device but the fallback `1`.

This PR fixes the wrong screen width reporting on iOS an doing so fixes the wrong cropping area.

This is related to https://github.com/gemini-testing/gemini/issues/279.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en