### PR TITLE
allow loading typescript presets in gemini tests

### DIFF
--- a/lib/sets-builder/index.js
+++ b/lib/sets-builder/index.js
@@ -8,7 +8,7 @@ const Promise = require('bluebird');
 const SetCollection = require('./set-collection');
 const TestSet = require('./test-set');
 
-const EXPAND_OPTS = {formats: ['.js']};
+const EXPAND_OPTS = {formats: ['.js', '.ts']};
 
 module.exports = class SetsBuilder {
     static create(sets, opts) {


### PR DESCRIPTION
We are going to write our tests in typescript using ts-node, but there is a limitation in code which filter out all files except of js