### PR TITLE
Feat: new styles of ignore areas (border, none)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ Utility which contains common modules for [gemini](https://github.com/gemini-tes
 - [Image](#image)
   - [Methods](#methods)
     - [crop](#crop)
+    - [getIgnoreAreas](#getignoreareas)
     - [getSize](#getsize)
     - [getRGBA](#getrgba)
     - [save](#save)
+    - [setIgnoreAreas](#setignoreareas)
     - [clear](#clear)
     - [join](#join)
   - [Static methods](#static-methods)
@@ -261,6 +263,10 @@ const cropArea = {
 image.crop(cropArea, 2); // will crop double sized image i.e width=200, heigth=200 etc.
 ```
 
+##### getIgnoreAreas
+
+Returns an array of objects representing image areas which were set by setIgnoreAreas method. They can be used in `compare` method.
+
 ##### getSize
 
 Returns object with current image size e.g. `{width: 100, height: 100}`
@@ -281,6 +287,29 @@ const color = image.getRGBA(1, 2); // {r: 255, g: 0, b: 0, a:255}
 
 Save image to the passed path. Asynchronous operation.
 Returns Promise with current image instance.
+
+##### setIgnoreAreas
+
+Bound list of areas to an image. Bounded areas will follow all image transformations (join, crop). Usefull in image comparision.
+
+```js
+const image = new Image(imgBuffer);
+const areas = [{
+        top: 10,
+        left: 10,
+        width: 100,
+        height: 100
+    },
+    {
+        top: 200,
+        left: 10,
+        width: 100,
+        height: 100
+    }
+];
+
+image.setIgnoreAreas(areas, {scaleFactor: 1});
+```
 
 ##### clear
 
@@ -333,7 +362,8 @@ const opts = {
     canHaveCaret: true,
     pixelRatio: 1,
     tolerance: 2,
-    antialiasingTolerance: 3
+    antialiasingTolerance: 3,
+    ignoreAreas: [{top: 0, left: 10, width: 50, height: 50}]
 };
 
 return Image.compare(path1, path2, opts)
@@ -352,6 +382,8 @@ const diffOpts = {
     current: '/curr/path/image.png',
     diff: '/diff/path/image.png',
     diffColor: '#f5f5f5',
+    ignoreAreas: [{top: 0, left: 10, width: 50, height: 50}],
+    ignoreAreasColor: '#face8d',
     tolerance: 2
 };
 

--- a/README.md
+++ b/README.md
@@ -383,7 +383,6 @@ const diffOpts = {
     diff: '/diff/path/image.png',
     diffColor: '#f5f5f5',
     ignoreAreas: [{top: 0, left: 10, width: 50, height: 50}],
-    ignoreAreasColor: '#face8d',
     tolerance: 2
 };
 

--- a/lib/image/index.js
+++ b/lib/image/index.js
@@ -13,12 +13,15 @@ module.exports = class Image {
 
     constructor(buffer) {
         this._img = new PngImg(buffer);
+        this._ignoreAreas = [];
     }
 
     crop(rect, opts = {}) {
         rect = this._scale(rect, (opts).scaleFactor);
         const imageSize = this.getSize();
         const safeRect = SafeRect.create(rect, imageSize);
+
+        this._cropAreas(safeRect);
 
         this._img.crop(
             safeRect.left,
@@ -28,6 +31,17 @@ module.exports = class Image {
         );
 
         return Promise.resolve(this);
+    }
+
+    _cropAreas(rect) {
+        this._ignoreAreas.forEach((area) => {
+            area.top -= rect.top;
+            area.left -= rect.left;
+        });
+    }
+
+    getIgnoreAreas() {
+        return this._ignoreAreas;
     }
 
     getSize() {
@@ -42,6 +56,12 @@ module.exports = class Image {
         return Promise.fromCallback((cb) => this._img.save(file, cb));
     }
 
+    setIgnoreAreas(areas, opts = {}) {
+        this._ignoreAreas = areas.map((area) => {
+            return this._scale(area, opts.scaleFactor);
+        });
+    }
+
     clear(area, opts = {}) {
         area = this._scale(area, (opts).scaleFactor);
         this._img.fill(
@@ -53,11 +73,57 @@ module.exports = class Image {
         );
     }
 
+    frame(area, opts = {}) {
+        area = this._scale(area, opts.scaleFactor);
+        const lineWidth = opts.scaleFactor,
+            color = '#feac88';
+
+        this._img.fill(
+            area.left,
+            area.top,
+            area.width,
+            lineWidth,
+            color
+        );
+        this._img.fill(
+            area.left,
+            area.top + area.height - lineWidth,
+            area.width,
+            lineWidth,
+            color
+        );
+        this._img.fill(
+            area.left,
+            area.top,
+            lineWidth,
+            area.height,
+            color
+        );
+        this._img.fill(
+            area.left + area.width - lineWidth,
+            area.top,
+            lineWidth,
+            area.height,
+            color
+        );
+    }
+
     join(newImage) {
         const imageSize = this.getSize();
+        const newIgnoreAreas = newImage.getIgnoreAreas();
+
         this._img
             .setSize(imageSize.width, imageSize.height + newImage.getSize().height)
             .insert(newImage._img, 0, imageSize.height);
+
+        newIgnoreAreas.forEach(({top, left, height, width}) => {
+            this._ignoreAreas.push({
+                top: top + imageSize.height,
+                left,
+                height,
+                width
+            });
+        });
 
         return this;
     }

--- a/lib/image/index.js
+++ b/lib/image/index.js
@@ -76,8 +76,9 @@ module.exports = class Image {
     frame(area, opts = {}) {
         area = this._scale(area, opts.scaleFactor);
         const lineWidth = opts.scaleFactor,
-            color = '#feac88';
+            color = '#000000';
 
+        /* top line */
         this._img.fill(
             area.left,
             area.top,
@@ -85,6 +86,8 @@ module.exports = class Image {
             lineWidth,
             color
         );
+
+        /* bottom line */
         this._img.fill(
             area.left,
             area.top + area.height - lineWidth,
@@ -92,6 +95,8 @@ module.exports = class Image {
             lineWidth,
             color
         );
+
+        /* left line */
         this._img.fill(
             area.left,
             area.top,
@@ -99,6 +104,8 @@ module.exports = class Image {
             area.height,
             color
         );
+
+        /* right line */
         this._img.fill(
             area.left + area.width - lineWidth,
             area.top,

--- a/lib/image/index.js
+++ b/lib/image/index.js
@@ -73,48 +73,6 @@ module.exports = class Image {
         );
     }
 
-    frame(area, opts = {}) {
-        area = this._scale(area, opts.scaleFactor);
-        const lineWidth = opts.scaleFactor,
-            color = '#000000';
-
-        /* top line */
-        this._img.fill(
-            area.left,
-            area.top,
-            area.width,
-            lineWidth,
-            color
-        );
-
-        /* bottom line */
-        this._img.fill(
-            area.left,
-            area.top + area.height - lineWidth,
-            area.width,
-            lineWidth,
-            color
-        );
-
-        /* left line */
-        this._img.fill(
-            area.left,
-            area.top,
-            lineWidth,
-            area.height,
-            color
-        );
-
-        /* right line */
-        this._img.fill(
-            area.left + area.width - lineWidth,
-            area.top,
-            lineWidth,
-            area.height,
-            color
-        );
-    }
-
     join(newImage) {
         const imageSize = this.getSize();
         const newIgnoreAreas = newImage.getIgnoreAreas();

--- a/lib/screen-shooter/index.js
+++ b/lib/screen-shooter/index.js
@@ -13,13 +13,13 @@ module.exports = class ScreenShooter {
         this._browser = browser;
     }
 
-    capture(page, {allowViewportOverflow = false, screenshotDelay} = {}) {
+    capture(page, {allowViewportOverflow = false, screenshotDelay, ignoreStyle} = {}) {
         return this._browser.captureViewportImage(page, screenshotDelay)
             .then((viewportImage) => Viewport.create(page.viewport, viewportImage, page.pixelRatio, allowViewportOverflow))
-            .then((viewport) => this._cropImage(viewport, page, screenshotDelay));
+            .then((viewport) => this._cropImage(viewport, page, screenshotDelay, ignoreStyle));
     }
 
-    _cropImage(viewport, page, screenshotDelay) {
+    _cropImage(viewport, page, screenshotDelay, ignoreStyle) {
         try {
             viewport.validate(page.captureArea, this._browser);
         } catch (e) {
@@ -28,7 +28,7 @@ module.exports = class ScreenShooter {
                 : Promise.reject(e);
         }
 
-        viewport.ignoreAreas(page.ignoreAreas);
+        viewport.ignoreAreas(page.ignoreAreas, ignoreStyle);
 
         return viewport.crop(page.captureArea);
     }

--- a/lib/screen-shooter/index.js
+++ b/lib/screen-shooter/index.js
@@ -13,13 +13,13 @@ module.exports = class ScreenShooter {
         this._browser = browser;
     }
 
-    capture(page, {allowViewportOverflow = false, screenshotDelay, ignoreStyle} = {}) {
+    capture(page, {allowViewportOverflow = false, screenshotDelay, ignoreElementsStyle} = {}) {
         return this._browser.captureViewportImage(page, screenshotDelay)
             .then((viewportImage) => Viewport.create(page.viewport, viewportImage, page.pixelRatio, allowViewportOverflow))
-            .then((viewport) => this._cropImage(viewport, page, screenshotDelay, ignoreStyle));
+            .then((viewport) => this._cropImage(viewport, page, screenshotDelay, ignoreElementsStyle));
     }
 
-    _cropImage(viewport, page, screenshotDelay, ignoreStyle) {
+    _cropImage(viewport, page, screenshotDelay, ignoreElementsStyle) {
         try {
             viewport.validate(page.captureArea, this._browser);
         } catch (e) {
@@ -27,8 +27,7 @@ module.exports = class ScreenShooter {
                 ? this._extendImage(viewport, page, screenshotDelay)
                 : Promise.reject(e);
         }
-
-        viewport.ignoreAreas(page.ignoreAreas, ignoreStyle);
+        viewport.ignoreAreas(page.ignoreAreas, ignoreElementsStyle);
 
         return viewport.crop(page.captureArea);
     }

--- a/lib/screen-shooter/viewport/index.js
+++ b/lib/screen-shooter/viewport/index.js
@@ -20,7 +20,7 @@ module.exports = class Viewport {
         CoordValidator.create(browser, {allowViewportOverflow: this._allowViewportOverflow}).validate(this._viewport, captureArea);
     }
 
-    ignoreAreas(areas, ignoreStyle = 'solid') {
+    ignoreAreas(areas, ignoreElementsStyle = 'solid') {
         const ignoreAreas = areas
             .map((area) => this._getIntersectionWithViewport(area))
             .filter(Boolean)
@@ -32,10 +32,10 @@ module.exports = class Viewport {
 
         this._image.setIgnoreAreas(ignoreAreas, {scaleFactor: this._pixelRatio});
 
-        if (ignoreStyle !== 'none') {
+        if (ignoreElementsStyle !== 'none') {
             ignoreAreas
                 .forEach((area) => {
-                    if (ignoreStyle === 'border') {
+                    if (ignoreElementsStyle === 'border') {
                         this._image.frame(area, {scaleFactor: this._pixelRatio});
                     } else {
                         this._image.clear(area, {scaleFactor: this._pixelRatio});

--- a/lib/screen-shooter/viewport/index.js
+++ b/lib/screen-shooter/viewport/index.js
@@ -20,11 +20,28 @@ module.exports = class Viewport {
         CoordValidator.create(browser, {allowViewportOverflow: this._allowViewportOverflow}).validate(this._viewport, captureArea);
     }
 
-    ignoreAreas(areas) {
-        _(areas)
+    ignoreAreas(areas, ignoreStyle = 'solid') {
+        const ignoreAreas = areas
             .map((area) => this._getIntersectionWithViewport(area))
-            .compact()
-            .forEach((area) => this._image.clear(this._transformToViewportOrigin(area), {scaleFactor: this._pixelRatio}));
+            .filter(Boolean)
+            .map((area) => this._transformToViewportOrigin(area));
+
+        if (!ignoreAreas.length) {
+            return;
+        }
+
+        this._image.setIgnoreAreas(ignoreAreas, {scaleFactor: this._pixelRatio});
+
+        if (ignoreStyle !== 'none') {
+            ignoreAreas
+                .forEach((area) => {
+                    if (ignoreStyle === 'border') {
+                        this._image.frame(area, {scaleFactor: this._pixelRatio});
+                    } else {
+                        this._image.clear(area, {scaleFactor: this._pixelRatio});
+                    }
+                });
+        }
     }
 
     crop(captureArea) {

--- a/lib/screen-shooter/viewport/index.js
+++ b/lib/screen-shooter/viewport/index.js
@@ -35,11 +35,7 @@ module.exports = class Viewport {
         if (ignoreElementsStyle !== 'none') {
             ignoreAreas
                 .forEach((area) => {
-                    if (ignoreElementsStyle === 'border') {
-                        this._image.frame(area, {scaleFactor: this._pixelRatio});
-                    } else {
-                        this._image.clear(area, {scaleFactor: this._pixelRatio});
-                    }
+                    this._image.clear(area, {scaleFactor: this._pixelRatio});
                 });
         }
     }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "gemini-configparser": "^1.0.0",
     "glob-extra": "^4.0.1",
     "lodash": "^4.15.0",
-    "looks-same": "^7.1.1",
+    "looks-same": "https://github.com/insane-developer/looks-same/tarball/ignore-areas",
     "micromatch": "^4.0.2",
     "png-img": "^2.1.1",
     "sizzle": "^2.3.3",

--- a/test/lib/image/index.js
+++ b/test/lib/image/index.js
@@ -194,6 +194,7 @@ describe('Image', () => {
             image.setIgnoreAreas(ignoreAreas, {scaleFactor: 2});
 
             const areas = image.getIgnoreAreas();
+
             assert.deepEqual(areas, [{
                 top: 20,
                 left: 30,

--- a/test/lib/image/index.js
+++ b/test/lib/image/index.js
@@ -181,4 +181,71 @@ describe('Image', () => {
                 });
             });
     });
+
+    describe('ignore areas', () => {
+        const ignoreAreas = [{
+            top: 10,
+            left: 15,
+            width: 50,
+            height: 40
+        }];
+
+        it('should consider pixelRatio for ignore areas', () => {
+            image.setIgnoreAreas(ignoreAreas, {scaleFactor: 2});
+
+            const areas = image.getIgnoreAreas();
+            assert.deepEqual(areas, [{
+                top: 20,
+                left: 30,
+                width: 100,
+                height: 80
+            }]);
+        });
+
+        it('should ajust ignore areas on image crop', () => {
+            image.setIgnoreAreas(ignoreAreas, {scaleFactor: 2});
+
+            sandbox.stub(PngImg.prototype, 'crop');
+
+            const rect = {left: 1, top: 2, width: 10, height: 10};
+
+            return image.crop(rect, {scaleFactor: 2})
+                .then(() => {
+                    const areas = image.getIgnoreAreas();
+                    assert.deepEqual(areas, [{
+                        top: 16,
+                        left: 28,
+                        width: 100,
+                        height: 80
+                    }]);
+                });
+        });
+
+        it('should merge ignore areas on image join', () => {
+            image.setIgnoreAreas(ignoreAreas);
+
+            sandbox.stub(PngImg.prototype, 'insert');
+            sandbox.stub(PngImg.prototype, 'setSize').returns(PngImg.prototype);
+            PngImg.prototype.size.returns({width: 150, height: 200});
+
+            image.join(image);
+
+            const areas = image.getIgnoreAreas();
+
+            assert.deepEqual(areas, [
+                {
+                    top: 10,
+                    left: 15,
+                    width: 50,
+                    height: 40
+                },
+                {
+                    top: 210,
+                    left: 15,
+                    width: 50,
+                    height: 40
+                }
+            ]);
+        });
+    });
 });

--- a/test/lib/screen-shooter/viewport/index.js
+++ b/test/lib/screen-shooter/viewport/index.js
@@ -71,7 +71,7 @@ describe('Viewport', () => {
 
             viewport.ignoreAreas([{top: 1, left: 1, width: 10, height: 10}]);
 
-            assert.calledWith(image.clear, {top: 1, left: 1, width: 10, height: 10}, {scaleFactor: 1});
+            assert.calledWith(image.setIgnoreAreas, [{top: 1, left: 1, width: 10, height: 10}], {scaleFactor: 1});
         });
 
         it('should transform area coordinates to a viewport origin', () => {
@@ -79,7 +79,7 @@ describe('Viewport', () => {
 
             viewport.ignoreAreas([{top: 1, left: 1, width: 10, height: 10}]);
 
-            assert.calledWith(image.clear, {top: 0, left: 0, width: 10, height: 10});
+            assert.calledWith(image.setIgnoreAreas, [{top: 0, left: 0, width: 10, height: 10}]);
         });
 
         it('should crop area size to a viewport origin (inside)', () => {
@@ -88,7 +88,7 @@ describe('Viewport', () => {
             const area = {top: 10, left: 5, width: 20, height: 5};
             viewport.ignoreAreas([area]);
 
-            assert.calledWith(image.clear, area);
+            assert.calledWith(image.setIgnoreAreas, [area]);
         });
 
         it('should crop area size to a viewport origin (bottom right)', () => {
@@ -96,7 +96,7 @@ describe('Viewport', () => {
 
             viewport.ignoreAreas([{top: 10, left: 5, width: 30, height: 5}]);
 
-            assert.calledWith(image.clear, {top: 10, left: 5, width: 25, height: 5});
+            assert.calledWith(image.setIgnoreAreas, [{top: 10, left: 5, width: 25, height: 5}]);
         });
 
         it('should crop area size to a viewport origin (top left)', () => {
@@ -104,7 +104,7 @@ describe('Viewport', () => {
 
             viewport.ignoreAreas([{top: 10, left: 5, width: 20, height: 20}]);
 
-            assert.calledWith(image.clear, {top: 0, left: 0, width: 10, height: 10});
+            assert.calledWith(image.setIgnoreAreas, [{top: 0, left: 0, width: 10, height: 10}]);
         });
 
         it('should not clear image if area is outside of viewport (bottom right)', () => {
@@ -112,7 +112,7 @@ describe('Viewport', () => {
 
             viewport.ignoreAreas([{top: 21, left: 31, width: 30, height: 5}]);
 
-            assert.notCalled(image.clear);
+            assert.notCalled(image.setIgnoreAreas);
         });
 
         it('should not clear image if area is outside of viewport (top left)', () => {
@@ -120,6 +120,24 @@ describe('Viewport', () => {
 
             viewport.ignoreAreas([{top: 0, left: 0, width: 30, height: 20}]);
 
+            assert.notCalled(image.setIgnoreAreas);
+        });
+
+        it('should call clear method if ignoreStyle = solid', () => {
+            const viewport = createViewport({coords: {top: 0, left: 0, width: 30, height: 20}, image, pixelRatio: 1});
+
+            viewport.ignoreAreas([{top: 10, left: 5, width: 20, height: 10}], 'solid');
+
+            assert.notCalled(image.frame);
+            assert.calledWith(image.clear, {top: 10, left: 5, width: 20, height: 10}, {scaleFactor: 1});
+        });
+
+        it('should call frame method if ignoreStyle = border', () => {
+            const viewport = createViewport({coords: {top: 0, left: 0, width: 30, height: 20}, image, pixelRatio: 1});
+
+            viewport.ignoreAreas([{top: 10, left: 5, width: 20, height: 10}], 'border');
+
+            assert.calledWith(image.frame, {top: 10, left: 5, width: 20, height: 10}, {scaleFactor: 1});
             assert.notCalled(image.clear);
         });
     });

--- a/test/lib/screen-shooter/viewport/index.js
+++ b/test/lib/screen-shooter/viewport/index.js
@@ -128,16 +128,14 @@ describe('Viewport', () => {
 
             viewport.ignoreAreas([{top: 10, left: 5, width: 20, height: 10}], 'solid');
 
-            assert.notCalled(image.frame);
             assert.calledWith(image.clear, {top: 10, left: 5, width: 20, height: 10}, {scaleFactor: 1});
         });
 
-        it('should call frame method if ignoreElementsStyle = border', () => {
+        it('should not call clear method if ignoreElementsStyle = none', () => {
             const viewport = createViewport({coords: {top: 0, left: 0, width: 30, height: 20}, image, pixelRatio: 1});
 
-            viewport.ignoreAreas([{top: 10, left: 5, width: 20, height: 10}], 'border');
+            viewport.ignoreAreas([{top: 10, left: 5, width: 20, height: 10}], 'none');
 
-            assert.calledWith(image.frame, {top: 10, left: 5, width: 20, height: 10}, {scaleFactor: 1});
             assert.notCalled(image.clear);
         });
     });

--- a/test/lib/screen-shooter/viewport/index.js
+++ b/test/lib/screen-shooter/viewport/index.js
@@ -123,7 +123,7 @@ describe('Viewport', () => {
             assert.notCalled(image.setIgnoreAreas);
         });
 
-        it('should call clear method if ignoreStyle = solid', () => {
+        it('should call clear method if ignoreElementsStyle = solid', () => {
             const viewport = createViewport({coords: {top: 0, left: 0, width: 30, height: 20}, image, pixelRatio: 1});
 
             viewport.ignoreAreas([{top: 10, left: 5, width: 20, height: 10}], 'solid');
@@ -132,7 +132,7 @@ describe('Viewport', () => {
             assert.calledWith(image.clear, {top: 10, left: 5, width: 20, height: 10}, {scaleFactor: 1});
         });
 
-        it('should call frame method if ignoreStyle = border', () => {
+        it('should call frame method if ignoreElementsStyle = border', () => {
             const viewport = createViewport({coords: {top: 0, left: 0, width: 30, height: 20}, image, pixelRatio: 1});
 
             viewport.ignoreAreas([{top: 10, left: 5, width: 20, height: 10}], 'border');


### PR DESCRIPTION
Based on https://github.com/gemini-testing/looks-same/pull/58
Ignore areas are now a part of image metadata, rather than black rectangle in picture itself.

So now there are 3 different styles for ignored areas:
- **solid** old way, black rectangle
- **border** 1px frame around area
- **none** no modifications made to the image

This PR is required for this one https://github.com/gemini-testing/hermione/pull/445