### PR TITLE
feat: disable window scrolling if allowViewportOverflow option is passed

### DIFF
--- a/lib/browser/client-scripts/index.js
+++ b/lib/browser/client-scripts/index.js
@@ -52,7 +52,9 @@ function prepareScreenshotUnsafe(selectors, opts) {
         }),
         pixelRatio = configurePixelRatio(opts.usePixelRatio);
 
-    if (!viewPort.rectInside(rect)) {
+    if (!opts.allowViewportOverflow && !viewPort.rectInside(rect)) {
+        window.scrollTo(rect.left, rect.top);
+    } else if (rect.top > viewPort.top || rect.left > viewPort.width) {
         window.scrollTo(rect.left, rect.top);
     }
 

--- a/lib/browser/client-scripts/index.js
+++ b/lib/browser/client-scripts/index.js
@@ -54,7 +54,7 @@ function prepareScreenshotUnsafe(selectors, opts) {
 
     if (!opts.allowViewportOverflow && !viewPort.rectInside(rect)) {
         window.scrollTo(rect.left, rect.top);
-    } else if (rect.top > viewPort.top || rect.left > viewPort.width) {
+    } else if (rect.top > (viewPort.top + viewPort.height) || rect.left > viewPort.width) {
         window.scrollTo(rect.left, rect.top);
     }
 

--- a/lib/screen-shooter/viewport/coord-validator/index.js
+++ b/lib/screen-shooter/viewport/coord-validator/index.js
@@ -31,7 +31,11 @@ module.exports = class CoordValidator {
         this._log('viewport size', viewport);
         this._log('crop area', cropArea);
 
-        if (!this._allowViewportOverflow && isOutsideOfViewport(viewport, cropArea)) {
+        if (this._allowViewportOverflow) {
+            return;
+        }
+
+        if (isOutsideOfViewport(viewport, cropArea)) {
             return this._reportOffsetViewportError();
         }
 
@@ -54,7 +58,8 @@ module.exports = class CoordValidator {
              - does not overflows the document
              - does not overflows browser viewport
             Alternatively, you can increase browser window size using
-            "setWindowSize" or "windowSize" option in the config file.`;
+            "setWindowSize" or "windowSize" option in the config file.
+            Also you can test such cases by setting "true" value to option "allowViewportOverflow" in the config file.`;
 
         throw new OffsetViewportError(message);
     }

--- a/test/lib/screen-shooter/viewport/coord-validator.js
+++ b/test/lib/screen-shooter/viewport/coord-validator.js
@@ -54,7 +54,7 @@ describe('CoordValidator', () => {
         });
     });
 
-    it('should not throw OffsetViewportError if option allowViewportOverflow is set', () => {
+    it('should not throw OffsetViewportError and HeightViewportError if option allowViewportOverflow is set', () => {
         coordValidator = new CoordValidator({id: 'some-browser-id'}, {allowViewportOverflow: true});
 
         assert.doesNotThrow(() => validate_({left: -1}));


### PR DESCRIPTION
При включенной опции `allowViewportOverflow` страница скролится только тогда, когда элемент полностью за пределами вьюпорта. Иначе делается снимок той части элемента, которая попала во вьюпорт.

Например, скриншот списка файлов(`.file-wrap`) репозитория [гермионы](https://github.com/gemini-testing/hermione), который после загрузки страницы виден частично при `windowSize: '1000x800'`:
![image](https://user-images.githubusercontent.com/24471472/65718864-1f439e80-e0ad-11e9-8d77-6905713f1dae.png)
