### PR TITLE
feat: increment stats for each test result

### DIFF
--- a/lib/base-stats/index.js
+++ b/lib/base-stats/index.js
@@ -8,7 +8,7 @@ module.exports = class BaseStats {
     }
 
     constructor(statNames) {
-        this._tests = {};
+        this._tests = new Set();
         this._retries = 0;
         this._statNames = statNames;
 
@@ -31,25 +31,11 @@ module.exports = class BaseStats {
         this._retries++;
     }
 
-    _addStat(stat, test) {
-        this._addStatOnce(stat, test, this._stats, this._tests);
-    }
-
-    _addStatOnce(stat, test, statsStorage, testsStorage) {
+    _addStat(stat, test, statsStorage = this._stats, testsStorage = this._tests) {
         const key = `${this._buildSuiteKey(test)} ${this._buildStateKey(test)}`;
-        const prevStat = testsStorage[key];
 
-        if (!prevStat) {
-            testsStorage[key] = stat;
-            statsStorage[stat]++;
-
-            return;
-        }
-
-        if (prevStat !== stat) {
-            statsStorage[prevStat]--;
-            statsStorage[stat]++;
-        }
+        statsStorage[stat]++;
+        testsStorage.add(key);
     }
 
     _fillEmptyStats() {
@@ -68,7 +54,7 @@ module.exports = class BaseStats {
 
     getResult() {
         return _.extend(this._stats, {
-            total: _.keys(this._tests).length,
+            total: this._tests.size,
             retries: this._retries
         });
     }


### PR DESCRIPTION
#### Проблема:
При реализации плагина `hermione-test-repeater` столкнулся с проблемой, что в случае если для одного теста прилетает 2 раза `TEST_PASS`, то он считается только один раз. Изначально эта логика появилась еще в gemini - https://github.com/gemini-testing/gemini/pull/649. Проблемы описанной в этом PR-е в hermione нет. Поэтому реализовал инкремент статистики на каждый вызов.