### PR TITLE
fix(calibrate): "window.innerWidth" always returns 980px in safari

### DIFF
--- a/lib/browser/client-scripts/calibrate.js
+++ b/lib/browser/client-scripts/calibrate.js
@@ -47,11 +47,21 @@
             !String.prototype.trim;
     }
 
+    // In safari `window.innerWidth` always returns default 980px and and even viewport meta tag setting does not change it.
+    // https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/UsingtheViewport/UsingtheViewport.html
+    function getInnerWidth() {
+        var isSafari = /Safari/.test(navigator.userAgent);
+
+        return isSafari
+            ? document.documentElement.clientWidth || document.body.clientWidth
+            : window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
+    }
+
     function getBrowserFeatures() {
         var features = {
             needsCompatLib: needsCompatLib(),
             pixelRatio: window.devicePixelRatio,
-            innerWidth: window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth
+            innerWidth: getInnerWidth()
         };
 
         return features;


### PR DESCRIPTION
#### Что сделано:
Оказалось, что в safari запущенном в симуляторе не правильно скриншотился вьюпорт по причине того, что `pixelRatio` вычислялся = 1. Из-за чего итоговый скриншот был уменьше в 2 раза по ширине и высоте. Как оказалось проблема в том, что `window.innerWidth` некорректно работает и всегда возвращает дефолтное значение. Подробнее про дефолтное значение в safari описано тут - https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/UsingtheViewport/UsingtheViewport.html#//apple_ref/doc/uid/TP40006509-SW27.

Не работает не только у меня =) :
- https://gist.github.com/Linrstudio/7236158c6c8d8103b9fb
- https://stackoverflow.com/questions/4629969/ios-return-bad-value-for-window-innerheight-width