### PR TITLE
fix(mobile safari): incorrect scroll by X coord

### DIFF
--- a/lib/browser/client-scripts/index.js
+++ b/lib/browser/client-scripts/index.js
@@ -55,7 +55,9 @@ function prepareScreenshotUnsafe(selectors, opts) {
         pixelRatio = configurePixelRatio(opts.usePixelRatio);
 
     if (captureElementFromTop && !viewPort.rectInside(rect)) {
-        window.scrollTo(rect.left, rect.top);
+        util.isSafariMobile()
+            ? scrollToCaptureAreaInSafari(viewPort, rect)
+            : window.scrollTo(rect.left, rect.top);
     } else if (allowViewportOverflow && viewPort.rectIntersects(rect)) {
         rect.overflowsTopBound(viewPort) && rect.recalculateHeight(viewPort);
         rect.overflowsLeftBound(viewPort) && rect.recalculateWidth(viewPort);
@@ -267,4 +269,19 @@ function isEditable(element) {
     }
     return /^(input|textarea)$/i.test(element.tagName) ||
         element.isContentEditable;
+}
+
+function scrollToCaptureAreaInSafari(viewportCurr, captureArea) {
+    window.scrollTo(viewportCurr.left, captureArea.top);
+
+    var viewportAfterScroll = new Rect({
+        left: util.getScrollLeft(),
+        top: util.getScrollTop(),
+        width: viewportCurr.width,
+        height: viewportCurr.height
+    });
+
+    if (!viewportAfterScroll.rectInside(captureArea)) {
+        window.scrollTo(captureArea.left, captureArea.top);
+    }
 }

--- a/lib/browser/client-scripts/util.js
+++ b/lib/browser/client-scripts/util.js
@@ -57,3 +57,7 @@ exports.getScrollLeft = function() {
 
     return document.documentElement.scrollLeft;
 };
+
+exports.isSafariMobile = function() {
+    return /(iPhone|iPad).*AppleWebKit.*Safari/i.test(navigator.userAgent);
+};


### PR DESCRIPTION
### Problem:
- window.scrollTo in safari works weird, you can set `window.scrollTo(10000, 10000)` and then get the current value of scroll left or top and get the same value that was passed. Even if there was no viewport movement at all. More info about this bug here - https://bugs.webkit.org/show_bug.cgi?id=179735

### What is done:
- for mobile safari I first scroll along the Y axis and then if captured area still not inside new recalculated viewport size, then I scroll again by X axis.