### PR TITLE
fix(mobile safari): temporary disable scroll by X coord

### DIFF
--- a/lib/browser/client-scripts/index.js
+++ b/lib/browser/client-scripts/index.js
@@ -274,6 +274,8 @@ function isEditable(element) {
 function scrollToCaptureAreaInSafari(viewportCurr, captureArea) {
     window.scrollTo(viewportCurr.left, captureArea.top);
 
+    // uncomment this block of code after fix bug - https://bugs.webkit.org/show_bug.cgi?id=179735
+    /*
     var viewportAfterScroll = new Rect({
         left: util.getScrollLeft(),
         top: util.getScrollTop(),
@@ -284,4 +286,5 @@ function scrollToCaptureAreaInSafari(viewportCurr, captureArea) {
     if (!viewportAfterScroll.rectInside(captureArea)) {
         window.scrollTo(captureArea.left, captureArea.top);
     }
+    */
 }


### PR DESCRIPTION
### Problem:
When user try to screen block which is outside of viewport (for example some carousel with video thumbs) then we try to scroll window by x coord and after that recalculate viewport coords. Due to the bug in safari - https://bugs.webkit.org/show_bug.cgi?id=179735 we get incorrect viewport position and therefore screen block incorrectly.

### What is done:
Temporary disable scroll by X coordinate in mobile safari because I didn't find any workaround =(
Moreover in most cases web sites in mobiles doesn't overflow viewport width so it's not a big problem.