### PR TITLE
Revert "fix(mobile safari): temporary disable scroll by X coord (#75)"

### DIFF
--- a/lib/browser/client-scripts/index.js
+++ b/lib/browser/client-scripts/index.js
@@ -274,8 +274,6 @@ function isEditable(element) {
 function scrollToCaptureAreaInSafari(viewportCurr, captureArea) {
     window.scrollTo(viewportCurr.left, captureArea.top);
 
-    // uncomment this block of code after fix bug - https://bugs.webkit.org/show_bug.cgi?id=179735
-    /*
     var viewportAfterScroll = new Rect({
         left: util.getScrollLeft(),
         top: util.getScrollTop(),
@@ -286,5 +284,4 @@ function scrollToCaptureAreaInSafari(viewportCurr, captureArea) {
     if (!viewportAfterScroll.rectInside(captureArea)) {
         window.scrollTo(captureArea.left, captureArea.top);
     }
-    */
 }


### PR DESCRIPTION
This reverts commit 3e436612c73ae6e2a3d040ddbd47131f43273862.

Due to the fact that I can't differ real safari from other browser with UA as in safari. So i can't temporary disable it only for real safari browser.