### PR TITLE
chore: update looks-same@7.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2297,9 +2297,9 @@
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "looks-same": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/looks-same/-/looks-same-7.2.4.tgz",
-      "integrity": "sha512-PUm/63gRQh4i7K85ZDhRjQCmg5tU9OwlO5O2AdgWJWYC/EhdCMCWJH2ozLfRJU63Dz9B/J/ZicKevkyOIaxxRg==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/looks-same/-/looks-same-7.3.0.tgz",
+      "integrity": "sha512-pOfwX2d0frSt7H1cuBjDbw9Kry5QwkrFri0qJvLwV1sI0cbWkwYkpd7fF7SqSIfYKAZhgeB8PM3fyhUYz7xgqA==",
       "requires": {
         "color-diff": "^1.1.0",
         "concat-stream": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "gemini-configparser": "^1.0.0",
     "glob-extra": "^5.0.0",
     "lodash": "^4.17.15",
-    "looks-same": "^7.2.4",
+    "looks-same": "^7.3.0",
     "micromatch": "^4.0.2",
     "png-img": "^3.3.0",
     "sizzle": "^2.3.3",


### PR DESCRIPTION
Up looks-same to use feature of compare images by buffers before trying to parse them.