### PR TITLE
fix: ability to work correctly with wdio@7 inside hermione

### DIFF
--- a/lib/browser-pool/basic-pool.js
+++ b/lib/browser-pool/basic-pool.js
@@ -36,7 +36,13 @@ module.exports = class BasicPool extends Pool {
             })
             .then(() => browser.reset())
             .then(() => browser)
-            .catch((e) => this.freeBrowser(browser).then(() => Promise.reject(e)));
+            .catch(async (e) => {
+                if (browser.publicAPI) {
+                    await this.freeBrowser(browser);
+                }
+
+                return Promise.reject(e);
+            });
     }
 
     freeBrowser(browser) {

--- a/test/lib/browser-pool/util.js
+++ b/test/lib/browser-pool/util.js
@@ -2,12 +2,13 @@
 
 const Promise = require('bluebird');
 
-exports.stubBrowser = function(id, version) {
+exports.stubBrowser = function(id, version, publicAPI = {}) {
     return {
         id: id || 'default-id',
         sessionId: process.hrtime().join('_'), // must be unique
         reset: sinon.stub().returns(Promise.resolve()),
         toPrint: sinon.stub().returns(id),
+        publicAPI,
         version
     };
 };


### PR DESCRIPTION
Wdio@7 has method [`remote`](https://github.com/webdriverio/webdriverio/blob/main/packages/webdriverio/src/index.ts#L31) which is create new wdio instance and [init new browser session by default inside](https://github.com/webdriverio/webdriverio/blob/main/packages/webdriverio/src/index.ts#L57). In wdio@4 method [`remote`](https://github.com/webdriverio/webdriverio/blob/v4.14.1/index.js#L28-L43) creates new wdio instance without init new session. There was separate command [`init`](https://github.com/webdriverio/webdriverio/blob/v4.14.1/lib/protocol/init.js) for this purpose.

It means that in wdio@4 if initializing session is failed hermione still has wdio instance and calls `browser.quit` doesn't fail.
But if in wdio@7 initializing session is failed (`remote` method) then session is empty inside hermione and I can't get `sessionId` or other session options/methods.

In order to take this case into account I check `browser.publicAPI` getter which returns initialized session. If session exists then I close it. If it doesn't exist then I have nothing to close.