### PR TITLE
feat(sets-collection): add groupByBrowserAndFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,12 @@ SetsBuilder
     .build('/root', globOpts, ['.js', '.ts'])   // builds a collection of sets with paths expanded according
                                                 // to the project root, glob options and file extensions
     .then((setCollection) => {
-        setCollection.groupByFile();    // groups all browsers of test-sets by file:
-                                        // {'desktop/tests/test.js': ['bro1']}
-        setCollection.groupByBrowser(); // groups all files of test-sets by browser:
-                                        // {'bro': ['desktop/tests/test.js']}
+        setCollection.groupByFile();            // groups all browsers of test-sets by file:
+                                                // {'desktop/tests/test.js': ['bro1']}
+        setCollection.groupByBrowser();         // groups all files of test-sets by browser:
+                                                // {'bro': ['desktop/tests/test.js']}
+        setCollection.groupByBrowserAndFile();  // groups all files of test-sets by browser and file:
+                                                // {'bro': { 'desktop/tests/test.js': ['desktop'] }}
     })
     .done();
 ```

--- a/lib/sets-builder/set-collection.js
+++ b/lib/sets-builder/set-collection.js
@@ -33,6 +33,34 @@ module.exports = class SetCollection {
         return _.zipObject(browsers, files);
     }
 
+    groupByBrowserAndFile() {
+        const result = {};
+
+        _(this._sets)
+            .forEach((set, setName) => {
+                const browsers = set.getBrowsers();
+                const files = set.getFiles();
+
+                browsers.forEach(browser => {
+                    if (!result[browser]) {
+                        result[browser] = {};
+                    }
+
+                    const browserSet = result[browser];
+
+                    files.forEach(file => {
+                        if (!browserSet[file]) {
+                            browserSet[file] = [];
+                        }
+
+                        browserSet[file].push(setName);
+                    });
+                });
+            });
+
+        return result;
+    }
+
     _getBrowsers() {
         return this._getFromSets((set) => set.getBrowsers());
     }

--- a/test/lib/sets-builder/set-collection.js
+++ b/test/lib/sets-builder/set-collection.js
@@ -51,4 +51,34 @@ describe('set-collection', () => {
             'bro3': ['some/files/file1.js', 'other/files/file2.js']
         });
     });
+
+    it('should group files by browser and file', () => {
+        const sets = {
+            set1: TestSet.create({
+                files: ['some/files/file1.js'],
+                browsers: ['bro1', 'bro3']
+            }),
+            set2: TestSet.create({
+                files: ['other/files/file2.js', 'some/files/file1.js'],
+                browsers: ['bro2', 'bro3']
+            })
+        };
+        const groupedFiles = SetCollection
+            .create(sets)
+            .groupByBrowserAndFile();
+
+        assert.deepEqual(groupedFiles, {
+            'bro1': {
+                'some/files/file1.js': ['set1']
+            },
+            'bro2': {
+                'some/files/file1.js': ['set2'],
+                'other/files/file2.js': ['set2']
+            },
+            'bro3': {
+                'some/files/file1.js': ['set1', 'set2'],
+                'other/files/file2.js': ['set2']
+            }
+        });
+    });
 });


### PR DESCRIPTION
Add groupByBrowserAndFile function to sets collection.

I need it to add `sets` property for every test results of hermione.

Hermione PR draft: https://github.com/gemini-testing/hermione/pull/564