### PR TITLE
fix(test-set): normalize paths for glob-extra library

### DIFF
--- a/lib/sets-builder/test-set.js
+++ b/lib/sets-builder/test-set.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 const mm = require('micromatch');
 const path = require('path');
 const Promise = require('bluebird');
+const normalize = require('normalize-path');
 
 const fs = Promise.promisifyAll(require('fs'));
 
@@ -24,7 +25,12 @@ module.exports = class TestSet {
             .concat(globOpts.ignore || [], ignoreFiles)
             .map((p) => path.resolve(expandOpts.root, p));
 
-        return globExtra.expandPaths(files, expandOpts, globOpts)
+        // glob-extra requires only forward-slashes,
+        // because it uses fast-glob https://github.com/mrmlnc/fast-glob#pattern-syntax)
+        globOpts.ignore = globOpts.ignore.map(e => normalize(e));
+        const normalizedFiles = files.map(e => normalize(e));
+
+        return globExtra.expandPaths(normalizedFiles, expandOpts, globOpts)
             .then((expandedFiles) => this._set = _.extend(this._set, {files: expandedFiles}));
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2665,8 +2665,7 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "npmlog": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lodash": "^4.17.15",
     "looks-same": "^7.3.0",
     "micromatch": "^4.0.2",
+    "normalize-path": "^3.0.0",
     "png-img": "^3.3.0",
     "sizzle": "^2.3.3",
     "temp": "^0.8.3",


### PR DESCRIPTION
Fix https://github.com/gemini-testing/hermione/issues/542

The problem was in glob-extra library, this library requires only forward-slashes because it uses fast-glob https://github.com/mrmlnc/fast-glob#pattern-syntax

Use normalize-path as suggested in https://github.com/mrmlnc/fast-glob#how-to-write-patterns-on-windows