### PR TITLE
feat: add xpath Support for screenshot testing

### DIFF
--- a/lib/browser/client-scripts/lib.compat.js
+++ b/lib/browser/client-scripts/lib.compat.js
@@ -1,13 +1,20 @@
 'use strict';
 /*jshint newcap:false*/
 var Sizzle = require('sizzle');
+var xpath = require('./xpath');
 
 exports.queryFirst = function(selector) {
+    if (xpath.isXpathSelector(selector)) {
+        return xpath.queryFirst(selector);
+    }
     var elems = Sizzle(exports.trim(selector) + ':first');
     return elems.length > 0 ? elems[0] : null;
 };
 
 exports.queryAll = function(selector) {
+    if (xpath.isXpathSelector(selector)) {
+        return xpath.queryAll(selector);
+    }
     return Sizzle(selector);
 };
 

--- a/lib/browser/client-scripts/lib.native.js
+++ b/lib/browser/client-scripts/lib.native.js
@@ -1,10 +1,17 @@
 'use strict';
+var xpath = require('./xpath');
 
 exports.queryFirst = function(selector) {
+    if (xpath.isXpathSelector(selector)) {
+        return xpath.queryFirst(selector);
+    }
     return document.querySelector(selector);
 };
 
 exports.queryAll = function(selector) {
+    if (xpath.isXpathSelector(selector)) {
+        return xpath.queryAll(selector);
+    }
     return document.querySelectorAll(selector);
 };
 

--- a/lib/browser/client-scripts/xpath.js
+++ b/lib/browser/client-scripts/xpath.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var XPATH_SELECTORS_START = [
+    '/', '(', '../', './', '*/'
+];
+
+function isXpathSelector(selector) {
+    return XPATH_SELECTORS_START.some(function(startString) {
+        return selector.startsWith(startString);
+    });
+}
+
+function queryFirst(selector) {
+    return document.evaluate(selector, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+}
+
+function queryAll(selector) {
+    var elements = document.evaluate(selector, document, null, XPathResult.ANY_TYPE, null);
+    var node, nodes = [];
+    node = elements.iterateNext();
+    while (node) {
+        nodes.push(node);
+        node = elements.iterateNext();
+    }
+    return nodes;
+}
+
+module.exports = {
+    isXpathSelector: isXpathSelector,
+    queryFirst: queryFirst,
+    queryAll: queryAll,
+}


### PR DESCRIPTION
Now browser.assertView supports only css-selectors:
![image](https://user-images.githubusercontent.com/33700405/132239933-3cb85f0e-a46e-492f-940e-5834095b8fa8.png)

